### PR TITLE
Add caching, pagination, redirects, better errors, & --org option to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,25 @@
 Designed to collect all collaborators of a given github repository, search their repos for a fork of the given repo and clone if found.
 The idea is to run as a nightly cron job to back up developer code and leaking IP that is not being pushed to their organization's repository.
 
+Using the option ``--org`` treats the positional argument ``<repo>`` as a Git organiztaion in which all repositories
+belonging to it will be backedup, including collaborator forks.
+
+The backup file structure is:
+```
+:path_from_-o/:timestamp/:org/:repo/:user/:repo/
+```
+
+__NOTE:__ Failed http requests to ``GET`` a repo's collaborator list do not raise, instead a warning is given and that repo is skipped.
+
+The following two aids are used to reduce the total number of Git API requests (API max 5000/hr):
+
+ * ``?per_page=100``
+ * responses are cached
+
 ## Usage
 ```
 usage: git-backup.py [-h] [-u <username>] [--oauth <token>] [-o <path>]
-                     [--fork_list_only] [-v] [--history <N>] [-p]
+                     [--org] [--fork_list_only] [-v] [--history <N>] [-p]
                      <repo>
 
 github repo backup
@@ -20,6 +35,8 @@ optional arguments:
                         GitHub username
   --oauth <token>       GitHub OAuth token
   -o <path>             Backup directory (default "./")
+  --org                 Treats positional argument <repo> as a git
+                        organization to backup
   --fork_list_only      Only print the list of users with forks of <repo>
   -v, --verbose         Make verbose
   --history <N>         Number of backups to maintain in backup dir. Older


### PR DESCRIPTION
…backup all org repos

Using the option ``--org`` treats the positional argument ``<repo>`` as a Git organiztaion in which all repositories belonging to it will
be backedup, including collaborator forks.

The backup file structure is:
```
:path_from_-o:/:timestamp/:org/:repo/:user/:repo/
```

__NOTE:__ Failed http requests to ``GET`` a repo's collaborator list do not raise, instead a warning is given and that repo is skipped.

The following two aids are used to reduce the total number of Git API requests made (API max 5000/hr):

 * ``?per_page=100``
 * responses are cached
Using the option ``--org`` treats the positional argument ``<repo>`` as a Git organiztaion in which all repositories belonging to it will
be backedup, including collaborator forks.

The backup file structure is:
```
:path_from_-o:/:timestamp/:org/:repo/:user/:repo/
```

__NOTE:__ Failed http requests to ``GET`` a repo's collaborator list do not raise, instead a warning is given and that repo is skipped.

The following two aids are used to reduce the total number of Git API requests made (API max 5000/hr):

 * ``?per_page=100``
 * responses are cached

resolves #1

Signed-off-by: James Noss <jnoss@stsci.edu>